### PR TITLE
Fjern registry fra dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       day: monday
       time: "06:00"
     open-pull-requests-limit: 10
-    registries:
-      - github
     groups:
       minor-deps:
         update-types:


### PR DESCRIPTION
Trenger ikke å sette opp siden vi ikke henter fra private repo