### PR TITLE
Fjern login-steg fra scan-vulnerabilities

### DIFF
--- a/.github/actions/trivy/action.yaml
+++ b/.github/actions/trivy/action.yaml
@@ -7,9 +7,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: nais/login@e7cf2c159677dc7c7d599feff5f808f2bf59c7cf # ratchet:nais/login@v0
-      with:
-        team: 'teamfamilie'
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # ratchet:aquasecurity/trivy-action@v0.30
       env: # Workaround until fixed: https://github.com/aquasecurity/trivy-action/issues/389

--- a/.github/workflows/scan-vulnerabilities-maven.yaml
+++ b/.github/workflows/scan-vulnerabilities-maven.yaml
@@ -18,10 +18,9 @@ jobs:
     permissions:
       contents: write # to write sarif
       security-events: write # push sarif to github security
-      id-token: write # nais/login
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
-        # CodeQL scan
+      # CodeQL scan
       - name: Initialize CodeQL
         uses: github/codeql-action/init@28deaeda66b76a05916b6923827895f2b14ab387 # ratchet:github/codeql-action/init@v3
         with:

--- a/.github/workflows/scan-vulnerabilities-yarn.yaml
+++ b/.github/workflows/scan-vulnerabilities-yarn.yaml
@@ -18,7 +18,6 @@ jobs:
     permissions:
       contents: write # to write sarif
       security-events: write # push sarif to github security
-      id-token: write # nais/login
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       # CodeQL scan


### PR DESCRIPTION
Trenger ikke å logge inn når man bygger image lokalt. Trenger heller ikke id-token permission siden vi ikke henter image.