### PR TITLE
CodeQL skal kun scanne kildekode

### DIFF
--- a/.github/workflows/scan-vulnerabilities-maven.yaml
+++ b/.github/workflows/scan-vulnerabilities-maven.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: github/codeql-action/init@28deaeda66b76a05916b6923827895f2b14ab387 # ratchet:github/codeql-action/init@v3
         with:
           languages: 'java-kotlin'
+          source-root: 'src'
       - name: Setup java and maven
         uses: navikt/familie-baks-gha-workflows/.github/actions/setup-java-maven@main # ratchet:exclude
         with:

--- a/.github/workflows/scan-vulnerabilities-yarn.yaml
+++ b/.github/workflows/scan-vulnerabilities-yarn.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: github/codeql-action/init@28deaeda66b76a05916b6923827895f2b14ab387 # ratchet:github/codeql-action/init@v3
         with:
           languages: 'javascript-typescript'
+          source-root: 'src'
       - name: Set up node and install yarn packages
         uses: navikt/familie-baks-gha-workflows/.github/actions/setup-node-yarn@main # ratchet:exclude
         with:


### PR DESCRIPTION
Fikk flere sikkerhetsvarsler på kompilert kode som ikke sa noe som helst.

Løses ved å sette source-root til 'src', da dette er vår standard plassering av kildekode. Alternativet ville vært å blackliste forskjellige filer og mapper. Prøver denne fremgangsmåten først.