### PR TITLE
Fiks manglende byosbom for maven-apper som sender inn sin egen sbom

### DIFF
--- a/.github/workflows/build-maven-app.yaml
+++ b/.github/workflows/build-maven-app.yaml
@@ -61,6 +61,7 @@ jobs:
           TESTCONTAINERS_REUSE_ENABLE: true
         with:
           skip-tests: ${{ inputs.skip-tests }}
+      # This check is actually required for the value to be passed along. The runner seems to "forget" the value if it is not used in a step.
       - name: Check if byosbom exists
         if: ${{ inputs.byosbom != '' }}
         run: |

--- a/.github/workflows/build-maven-app.yaml
+++ b/.github/workflows/build-maven-app.yaml
@@ -61,16 +61,12 @@ jobs:
           TESTCONTAINERS_REUSE_ENABLE: true
         with:
           skip-tests: ${{ inputs.skip-tests }}
-      - name: Show working directory
-        run: pwd
-      - name: List files in working directory
-        run: ls
       - name: Print SBOM file (if exists)
         if: ${{ inputs.byosbom != '' }}
         run: |
           if [ -f "${{ inputs.byosbom }}" ]; then
             echo "SBOM file exists at ${{ inputs.byosbom }}:"
-            head -n 20 "${{ inputs.byosbom }}"
+            head -n 10 "${{ inputs.byosbom }}"
           else
             echo "SBOM file not found at path: ${{ inputs.byosbom }}"
           fi

--- a/.github/workflows/build-maven-app.yaml
+++ b/.github/workflows/build-maven-app.yaml
@@ -61,14 +61,13 @@ jobs:
           TESTCONTAINERS_REUSE_ENABLE: true
         with:
           skip-tests: ${{ inputs.skip-tests }}
-      - name: Print SBOM file (if exists)
+      - name: Check if byosbom exists
         if: ${{ inputs.byosbom != '' }}
         run: |
           if [ -f "${{ inputs.byosbom }}" ]; then
-            echo "SBOM file exists at ${{ inputs.byosbom }}:"
-            head -n 10 "${{ inputs.byosbom }}"
+            echo "SBOM file exists"
           else
-            echo "SBOM file not found at path: ${{ inputs.byosbom }}"
+            echo "SBOM file not found"
           fi
       - name: Build and push docker image
         id: build-push-docker-image

--- a/.github/workflows/build-maven-app.yaml
+++ b/.github/workflows/build-maven-app.yaml
@@ -61,7 +61,19 @@ jobs:
           TESTCONTAINERS_REUSE_ENABLE: true
         with:
           skip-tests: ${{ inputs.skip-tests }}
-      # TODO: Sonar analyse
+      - name: Show working directory
+        run: pwd
+      - name: List files in working directory
+        run: ls
+      - name: Print SBOM file (if exists)
+        if: ${{ inputs.byosbom != '' }}
+        run: |
+          if [ -f "${{ inputs.byosbom }}" ]; then
+            echo "SBOM file exists at ${{ inputs.byosbom }}:"
+            head -n 20 "${{ inputs.byosbom }}"
+          else
+            echo "SBOM file not found at path: ${{ inputs.byosbom }}"
+          fi
       - name: Build and push docker image
         id: build-push-docker-image
         if: inputs.build-image


### PR DESCRIPTION
Tidligere endring tok imot en sbom, men av en eller annen grunn ble ikke dette sendt til nais. Oppdaget noe rar oppførsel under debugging, hvor hvis jeg printet innholdet så ble sbom-en sendt med korrekt. Jeg fant ikke noe info som diskuterte problemet foruten at det kanskje er forskjellige runner-e som jobber om hverandre. Hvor i så fall min teori er at den som kjører action-et 'build-push-docker-image' ikke har tilgang til filene som ble generert av maven.

Løsning blir derfor bare en enkel sjekk om filen faktisk eksisterer. Det er sikkert andre måter å løse dette, men anser dette som en enkel måte å komme seg rundt problematikken uten altfor mye oppsett.