### PR TITLE
Legg til Harden-Runner i workflows

### DIFF
--- a/.github/workflows/build-maven-app.yaml
+++ b/.github/workflows/build-maven-app.yaml
@@ -48,6 +48,10 @@ jobs:
     outputs:
       image: ${{ steps.build-push-docker-image.outputs.image }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # ratchet:step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       - name: Setup java and maven

--- a/.github/workflows/build-yarn-app.yaml
+++ b/.github/workflows/build-yarn-app.yaml
@@ -58,6 +58,10 @@ jobs:
     outputs:
       image: ${{ steps.build-push-docker-image.outputs.image }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # ratchet:step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       - name: Set up node and install yarn packages

--- a/.github/workflows/deploy-with-tag.yaml
+++ b/.github/workflows/deploy-with-tag.yaml
@@ -28,6 +28,10 @@ jobs:
     name: Manual deploy
     runs-on: ${{ inputs.runs-on }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # ratchet:step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       - name: Deploy to ${{ inputs.cluster }} from GAR
         uses: navikt/familie-baks-gha-workflows/.github/actions/deploy@main # ratchet:exclude

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,6 +27,10 @@ jobs:
       id-token: write # nais/deploy
     runs-on: ${{ inputs.runs-on }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # ratchet:step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       - name: Deploy to ${{ inputs.cluster }} from GAR
         uses: navikt/familie-baks-gha-workflows/.github/actions/deploy@main # ratchet:exclude

--- a/.github/workflows/scan-vulnerabilities-maven.yaml
+++ b/.github/workflows/scan-vulnerabilities-maven.yaml
@@ -19,6 +19,10 @@ jobs:
       contents: write # to write sarif
       security-events: write # push sarif to github security
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # ratchet:step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       # CodeQL scan
       - name: Initialize CodeQL

--- a/.github/workflows/scan-vulnerabilities-yarn.yaml
+++ b/.github/workflows/scan-vulnerabilities-yarn.yaml
@@ -19,6 +19,10 @@ jobs:
       contents: write # to write sarif
       security-events: write # push sarif to github security
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # ratchet:step-security/harden-runner@v2
+        with:
+          egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       # CodeQL scan
       - name: Initialize CodeQL


### PR DESCRIPTION
Skrur på Harden-Runner i audit-mode for å få en bedre oversikt over hvilke endepunkter vi snakker med. På sikt skal disse bli til en whitelist.