### PR TITLE
Opprett gjenbrukbar action for Slack-varsling

### DIFF
--- a/.github/actions/notify-slack/action.yaml
+++ b/.github/actions/notify-slack/action.yaml
@@ -15,7 +15,7 @@ runs:
     - name: Post message to Slack
       shell: bash
       run: |
-        curl -X POST --data "{\"text\": \"$MESSAGE\"}" "SLACK_WEBHOOK"
+        curl -X POST --data "{\"text\": \"$MESSAGE\"}" "$SLACK_WEBHOOK"
       env:
         MESSAGE: ${{ inputs.message }}
         SLACK_WEBHOOK: ${{ inputs.slack_webhook }}

--- a/.github/actions/notify-slack/action.yaml
+++ b/.github/actions/notify-slack/action.yaml
@@ -1,0 +1,21 @@
+name: Notify Slack
+description: Post a message to a Slack channel via incoming webhook
+
+inputs:
+  message:
+    required: true
+    description: 'The message to post to Slack'
+  slack_webhook:
+    required: true
+    description: 'Slack incoming webhook URL'
+
+runs:
+  using: composite
+  steps:
+    - name: Post message to Slack
+      shell: bash
+      run: |
+        curl -X POST --data "{\"text\": \"$MESSAGE\"}" "SLACK_WEBHOOK"
+      env:
+        MESSAGE: ${{ inputs.message }}
+        SLACK_WEBHOOK: ${{ inputs.slack_webhook }}

--- a/.github/workflows/notify-audited-deploy.yaml
+++ b/.github/workflows/notify-audited-deploy.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Post in slack
         uses: navikt/familie-baks-gha-workflows/.github/actions/notify-slack@slack-varsling # ratchet:exclude
         with:
-          message: "${{ github.actor }} har deployet til prod fra branch: ${{ github.ref_name }} i repo: ${{ github.repository }}\n\
+          message: "${{ github.actor }} har deployet til prod fra branch: `${{ github.ref_name }}` i repo: ${{ github.repository }}\n\
             Kommenter det som er gjort og hvorfor.\n\
             Deploy: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           slack_webhook: ${{ secrets.BAKS_AUDIT_ALERTS_SLACK_WEBHOOK }}

--- a/.github/workflows/notify-audited-deploy.yaml
+++ b/.github/workflows/notify-audited-deploy.yaml
@@ -1,0 +1,30 @@
+name: Notify audited deploy
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        required: false
+        type: string
+        description: 'Which runner image to run the workflow.'
+        default: 'ubuntu-latest'
+    secrets:
+      BAKS_AUDIT_ALERTS_SLACK_WEBHOOK:
+        required: true
+
+jobs:
+  notify-audited-deploy:
+    name: Notify audited deploy
+    runs-on: ${{ inputs.runs-on }}
+    permissions: {}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # ratchet:step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - name: Post in slack
+        uses: navikt/familie-baks-gha-workflows/.github/actions/notify-slack@slack-varsling # ratchet:exclude
+        with:
+          message: "${{ github.actor }} har deployet til prod fra branch: ${{ github.ref_name }} i repo: ${{ github.repository }}\n\
+            Kommenter det som er gjort og hvorfor.\n\
+            Deploy: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack_webhook: ${{ secrets.BAKS_AUDIT_ALERTS_SLACK_WEBHOOK }}

--- a/.github/workflows/notify-audited-deploy.yaml
+++ b/.github/workflows/notify-audited-deploy.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Post in slack
-        uses: navikt/familie-baks-gha-workflows/.github/actions/notify-slack@slack-varsling # ratchet:exclude
+        uses: navikt/familie-baks-gha-workflows/.github/actions/notify-slack@main # ratchet:exclude
         with:
           message: "${{ github.actor }} har deployet til prod fra branch: `${{ github.ref_name }}` i repo: ${{ github.repository }}\n\
             Kommenter det som er gjort og hvorfor.\n\

--- a/.github/workflows/notify-failed-workflow.yaml
+++ b/.github/workflows/notify-failed-workflow.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Post in slack
-        uses: navikt/familie-baks-gha-workflows/.github/actions/notify-slack@slack-varsling # ratchet:exclude
+        uses: navikt/familie-baks-gha-workflows/.github/actions/notify-slack@main # ratchet:exclude
         with:
           message: "Workflow: `${{ github.workflow }}` feilet for ${{ github.repository }} - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           slack_webhook: ${{ secrets.BAKS_DEPLOYMENTS_SLACK_WEBHOOK }}

--- a/.github/workflows/notify-failed-workflow.yaml
+++ b/.github/workflows/notify-failed-workflow.yaml
@@ -1,0 +1,28 @@
+name: Notify failed workflow
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        required: false
+        type: string
+        description: 'Which runner image to run the workflow.'
+        default: 'ubuntu-latest'
+    secrets:
+      BAKS_DEPLOYMENTS_SLACK_WEBHOOK:
+        required: true
+
+jobs:
+  notify-failed-workflow:
+    name: Notify failed workflow
+    runs-on: ${{ inputs.runs-on }}
+    permissions: {}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # ratchet:step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - name: Post in slack
+        uses: navikt/familie-baks-gha-workflows/.github/actions/notify-slack@slack-varsling # ratchet:exclude
+        with:
+          message: "Workflow: `${{ github.workflow }}` feilet for ${{ github.repository }} - ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          slack_webhook: ${{ secrets.BAKS_DEPLOYMENTS_SLACK_WEBHOOK }}


### PR DESCRIPTION
### 📮 Favro: NAV-28509

### 💰 Hva skal gjøres, og hvorfor?
Legger til varsling workflow som skal brukes for å varsle #team-baks-audit-alerts hvis noen deployer fra ikke-main branch.

Omskriver også notify-slack workflow til å bli notify-failed-deploy. I hovedsak en rename av input og workflow. Gamle workflow er beholdt for bakoverkompabilitet.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Innhold i melding.

Skjermbilde:
<img width="860" height="127" alt="image" src="https://github.com/user-attachments/assets/ec3bde05-a3f5-4a6b-a422-8db86053705d" />
