### PR TITLE
Ta i mot image-name i deploy-with-tag for utypiske image navn

### DIFF
--- a/.github/workflows/build-maven-app.yaml
+++ b/.github/workflows/build-maven-app.yaml
@@ -82,8 +82,8 @@ jobs:
         with:
           push-image: ${{ inputs.push-image }}
           byosbom: ${{ inputs.byosbom }}
-      - name: Display image name
+      - name: Print image in summary
         if: steps.build-push-docker-image.outputs.image != ''
         run: |
-          echo "## Image name" >> $GITHUB_STEP_SUMMARY
+          echo "## Image" >> $GITHUB_STEP_SUMMARY
           echo "\`${{ steps.build-push-docker-image.outputs.image }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-pnpm-app.yaml
+++ b/.github/workflows/build-pnpm-app.yaml
@@ -100,8 +100,8 @@ jobs:
         with:
           push-image: ${{ inputs.push-image }}
           image-suffix: ${{ inputs.build-profile }}
-      - name: Display image name
+      - name: Print image in summary
         if: steps.build-push-docker-image.outputs.image != ''
         run: |
-          echo "## Image name" >> $GITHUB_STEP_SUMMARY
+          echo "## Image" >> $GITHUB_STEP_SUMMARY
           echo "\`${{ steps.build-push-docker-image.outputs.image }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-yarn-app.yaml
+++ b/.github/workflows/build-yarn-app.yaml
@@ -101,8 +101,8 @@ jobs:
         with:
           push-image: ${{ inputs.push-image }}
           image-suffix: ${{ inputs.build-profile }}
-      - name: Display image name
+      - name: Print image in summary
         if: steps.build-push-docker-image.outputs.image != ''
         run: |
-          echo "## Image name" >> $GITHUB_STEP_SUMMARY
+          echo "## Image" >> $GITHUB_STEP_SUMMARY
           echo "\`${{ steps.build-push-docker-image.outputs.image }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-with-tag.yaml
+++ b/.github/workflows/deploy-with-tag.yaml
@@ -2,6 +2,10 @@ name: Manual deploy
 on:
   workflow_call:
     inputs:
+      image-name:
+        required: false
+        type: string
+        description: 'Image name, defaults to repo name. Used for environment-specific images'
       image-tag:
         required: true
         type: string
@@ -21,7 +25,9 @@ on:
         default: 'ubuntu-latest'
 
 env:
-  IMAGE_PATH: europe-north1-docker.pkg.dev/nais-management-233d/teamfamilie/${{ github.event.repository.name }}
+  IMAGE_REGISTRY: europe-north1-docker.pkg.dev/nais-management-233d/teamfamilie
+  IMAGE_NAME: ${{ inputs.image-name || github.event.repository.name }}
+  IMAGE_TAG: ${{ inputs.image-tag }}
 
 jobs:
   manual-deploy:
@@ -41,4 +47,4 @@ jobs:
         with:
           cluster: ${{ inputs.cluster }}
           resource: ${{ inputs.resource }}
-          image: ${{ env.IMAGE_PATH }}:${{ inputs.image-tag }}
+          image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}


### PR DESCRIPTION
### 📮 Favro: NAV-28509

### 💰 Hva skal gjøres, og hvorfor?
Tidligere default brukte repo-navn som image-navn, som funker bra for de fleste apper. Det funker derimot ikke for apper som nylig har tatt i bruk miljø-spesifikke images. F.eks ba-sak-frontend. Da heter image-et: `familie-ba-sak-frontend-prod`. Legger til støtte å sette dette som parameter, med repo-navn som default.

Rydder også litt opp i språkbruken i GitHub summary.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei
