### PR TITLE
NAV-22519: Eksponer deployet branch som nais-variabel

### DIFF
--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -10,6 +10,10 @@ inputs:
   resource:
     required: true
     description: 'The path to the nais (yaml) resource file to use'
+  branch:
+    required: false
+    default: ''
+    description: 'Branchen imaget er bygget fra. Utledes fra github.ref_name hvis den ikke oppgis. Sett til "ukjent" når imaget ikke er bygget fra ref-en som trigget deployet.'
 
 runs:
   using: 'composite'
@@ -20,9 +24,10 @@ runs:
         REPO_NAME: ${{ github.event.repository.name }}
         GITHUB_SHA: ${{ github.sha }}
         GITHUB_REF_NAME: ${{ github.ref_name }}
+        BRANCH_INPUT: ${{ inputs.branch }}
       run: |
         echo "VERSION=$REPO_NAME:$GITHUB_SHA" >> $GITHUB_ENV
-        echo "BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
+        echo "BRANCH=${BRANCH_INPUT:-$GITHUB_REF_NAME}" >> $GITHUB_ENV
     - name: Deploy til ${{ inputs.cluster }} fra GAR
       uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
       env:

--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -18,7 +18,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Set version
+    - name: Define env variables
       shell: bash
       env:
         REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -19,10 +19,13 @@ runs:
       env:
         REPO_NAME: ${{ github.event.repository.name }}
         GITHUB_SHA: ${{ github.sha }}
-      run: echo "VERSION=$REPO_NAME:$GITHUB_SHA" >> $GITHUB_ENV
+        GITHUB_REF_NAME: ${{ github.ref_name }}
+      run: |
+        echo "VERSION=$REPO_NAME:$GITHUB_SHA" >> $GITHUB_ENV
+        echo "BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
     - name: Deploy til ${{ inputs.cluster }} fra GAR
       uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # ratchet:nais/deploy/actions/deploy@v2
       env:
         CLUSTER: ${{ inputs.cluster }}
         RESOURCE: ${{ inputs.resource }}
-        VAR: image=${{ inputs.image }},VERSION=${{ env.VERSION }}
+        VAR: image=${{ inputs.image }},VERSION=${{ env.VERSION }},BRANCH=${{ env.BRANCH }}

--- a/.github/workflows/deploy-with-tag.yaml
+++ b/.github/workflows/deploy-with-tag.yaml
@@ -50,4 +50,5 @@ jobs:
           image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           # Imaget deployes fra en vilkårlig tag og er ikke nødvendigvis bygget fra
           # ref-en som trigget dette deployet, så vi kan ikke utlede branchen.
-          branch: ukjent
+          # Tag-en er mer informativ enn ingenting, og er sporbar tilbake til commit.
+          branch: "tag:${{ inputs.image-tag }}"

--- a/.github/workflows/deploy-with-tag.yaml
+++ b/.github/workflows/deploy-with-tag.yaml
@@ -48,3 +48,6 @@ jobs:
           cluster: ${{ inputs.cluster }}
           resource: ${{ inputs.resource }}
           image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          # Imaget deployes fra en vilkårlig tag og er ikke nødvendigvis bygget fra
+          # ref-en som trigget dette deployet, så vi kan ikke utlede branchen.
+          branch: ukjent

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,8 +34,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
       - name: Deploy to ${{ inputs.cluster }} from GAR
-        # TODO NAV-22519: sett tilbake til @main før merge
-        uses: navikt/familie-baks-gha-workflows/.github/actions/deploy@NAV-22519_eksponer_deployet_branch # ratchet:exclude
+        uses: navikt/familie-baks-gha-workflows/.github/actions/deploy@main # ratchet:exclude
         with:
           cluster: ${{ inputs.cluster }}
           resource: ${{ inputs.resource }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,7 +34,8 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
       - name: Deploy to ${{ inputs.cluster }} from GAR
-        uses: navikt/familie-baks-gha-workflows/.github/actions/deploy@main # ratchet:exclude
+        # TODO NAV-22519: sett tilbake til @main før merge
+        uses: navikt/familie-baks-gha-workflows/.github/actions/deploy@NAV-22519_eksponer_deployet_branch # ratchet:exclude
         with:
           cluster: ${{ inputs.cluster }}
           resource: ${{ inputs.resource }}


### PR DESCRIPTION
### 📮 Favro: NAV-22519

### 💰 Hva skal gjøres, og hvorfor?
Testere som verifiserer i preprod har ingen måte å se hvilken branch som faktisk er deployet. Denne PR-en eksponerer branchen som nais-variabelen `BRANCH`, på samme måte som `VERSION` allerede eksponeres, slik at appene kan vise den i GUI-et.

- `.github/actions/deploy/action.yaml`: setter `BRANCH` og legger den på `VAR`. `branch` er en valgfri input som defaulter til `github.ref_name`.
- `.github/workflows/deploy-with-tag.yaml`: sender `branch: "tag:<image-tag>"`. Den deployer et vilkårlig image-tag som ikke nødvendigvis er bygget fra ref-en som trigget deployet — da ville `github.ref_name` gitt feil branch (typisk `main`), og en feil branch er verre enn ingen branch for nettopp den målgruppen funksjonen er laget for.

Endringen er bakoverkompatibel: nais ignorerer template-variabler som ikke er i bruk, så repo som ikke refererer `{{ BRANCH }}` er upåvirket. Det er allerede bevist av `VERSION`, som flere `app-prod.yaml` aldri har referert.